### PR TITLE
Add a new env variable

### DIFF
--- a/app.Dockerfile
+++ b/app.Dockerfile
@@ -5,6 +5,7 @@ RUN mvn -f /usr/src/app/pom.xml clean package
 
 FROM openjdk:8-jdk-alpine
 
+ENV SPRING_JPA_PROPERTIES_HIBERNATE_DIALECT org.hibernate.dialect.MySQLDialect
 ENV SPRING_DATASOURCE_URL jdbc:mysql://localhost:3306/IS2?allowPublicKeyRetrieval=true&useSSL=false&useUnicode=true&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=UTC
 
 COPY --from=build /usr/src/app/target/is2.jar /usr/app/is2.jar


### PR DESCRIPTION
It seems that te variable spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect is needed to make the container alive with the database